### PR TITLE
Use rayon to speed up yuv to rgb conversion.

### DIFF
--- a/openh264/Cargo.toml
+++ b/openh264/Cargo.toml
@@ -14,13 +14,15 @@ repository = "https://github.com/ralfbiedert/openh264-rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["decoder", "encoder"]
+default = ["decoder", "encoder", "rayon"]
 decoder = ["openh264-sys2/decoder"]
 encoder = ["openh264-sys2/encoder"]
 backtrace = [] # Remove once backtrace feature is stable.
+rayon = ["dep:rayon"]
 
 [dependencies]
 openh264-sys2 = { path = "../openh264-sys2", version = "0.3.0", default-features = false }
+rayon = { version = "1.6.1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
An optional feature `rayon` is added to enable the use of rayon to speed up yuv to rgb conversion (line by line). On my Laptop (i7-12700H) this improves the decoding frame rate of a 720x1080 video from around `200` fps to `260` fps.