### PR TITLE
Update image-compare to 0.3.0

### DIFF
--- a/openh264/Cargo.toml
+++ b/openh264/Cargo.toml
@@ -27,8 +27,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
-image = "0.24.4"
-image-compare = "0.2.3"
+image = "0.24.6"
+image-compare = "0.3.0"
+
 mp4 = "0.13.0"
 anyhow = "1.0.71"
 


### PR DESCRIPTION
This just bumps the crate version of image and image-compare.
API did not change for your use-case in the tests.