### PR TITLE
feat: add faster RGB to YUV conversion

### DIFF
--- a/openh264/Cargo.toml
+++ b/openh264/Cargo.toml
@@ -17,10 +17,12 @@ repository = "https://github.com/ralfbiedert/openh264-rust"
 default = ["decoder", "encoder"]
 decoder = ["openh264-sys2/decoder"]
 encoder = ["openh264-sys2/encoder"]
+libyuv  = ["dep:libyuv"]
 backtrace = [] # Remove once backtrace feature is stable.
 
 [dependencies]
 openh264-sys2 = { path = "../openh264-sys2", version = "0.4.0", default-features = false }
+libyuv = { version = "0.1.2", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
use [libyuv](https://github.com/mycrl/libyuv-rs)  for rgb to yuv color conversion which is faster than correct implementation and also adding support for argb to yuv

test on i7-11800H 
```
-- Default --
test convert_rgb_to_yuv_1920x1080 ... bench:  10,345,450 ns/iter (+/- 1,524,720)
test convert_rgb_to_yuv_512x512   ... bench:   1,242,450 ns/iter (+/- 47,673)
-- libyuv--
test convert_rgb_to_yuv_1920x1080 ... bench:   4,223,560 ns/iter (+/- 76,388)
test convert_rgb_to_yuv_512x512   ... bench:     534,990 ns/iter (+/- 26,721)
```