### PR TITLE
Allow encoding 4K vertical videos

### DIFF
--- a/openh264/src/encoder.rs
+++ b/openh264/src/encoder.rs
@@ -350,13 +350,16 @@ impl Encoder {
     #[rustfmt::skip]
     fn reinit(&mut self, width: i32, height: i32) -> Result<(), Error> {
         // https://github.com/cisco/openh264/blob/master/README.md
-        // > Encoder errors when resolution exceeds 3840x2160
+        // > Encoder errors when resolution exceeds 3840x2160 or 2160x3840
         //
         // Some more detail here:
         // https://github.com/cisco/openh264/issues/3553
         // > Currently the encoder/decoder could only support up to level 5.2,
-        if width > 3840 || height > 2160 {
-            return Err(Error::msg("Encoder max resolution 3840x2160"));
+        let greater_dim = std::cmp::max(width, height);
+        let smaller_dim = std::cmp::min(width, height);
+
+        if greater_dim > 3840 || smaller_dim > 2160 {
+            return Err(Error::msg("Encoder max resolution 3840x2160 horizontal or 2160x3840 vertical"));
         }
 
         let mut params = SEncParamExt::default();


### PR DESCRIPTION
This PR modifies the resolution check, so that 2160x3840 is supported. OpenH264 has a 4K resolution limit, but it can be either horizontal or vertical. I've tested the solution by successfully encoding a video from Pixel 3A with 1080x2220 resolution – previously it would error out since the height (2220) exceeds 2160px.