### PR TITLE
Fix OpenH264 error on videos with Bframes

### DIFF
--- a/openh264/examples/mp4/main.rs
+++ b/openh264/examples/mp4/main.rs
@@ -2,7 +2,7 @@ mod mp4_bitstream_converter;
 
 use crate::mp4_bitstream_converter::Mp4BitstreamConverter;
 use anyhow::{anyhow, Error};
-use openh264::decoder::{Decoder, DecoderConfig};
+use openh264::decoder::{DecodeOptions, Decoder, DecoderConfig};
 use std::{
     fs::File,
     io::{Cursor, Read, Write},
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
 
         // convert the packet from mp4 representation to one that openh264 can decode
         bitstream_converter.convert_packet(&sample.bytes, &mut buffer);
-        match decoder.decode_no_flush(&buffer) {
+        match decoder.decode_with_options(&buffer, DecodeOptions::NoFlush) {
             Ok(Some(image)) => {
                 image.write_rgb8(&mut rgb);
                 save_file(&format!("{out}/frame-0{:04}.ppm", frame_idx), &rgb, width, height)?;

--- a/openh264/tests/data/big_buck_bunny_640x360.h264
+++ b/openh264/tests/data/big_buck_bunny_640x360.h264
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78a0bb2b1c47f37e295667e075e9e816eb0ae4a5a3b85ea95b4b1d8b3ba179a6
+size 5225354

--- a/openh264/tests/decode.rs
+++ b/openh264/tests/decode.rs
@@ -171,6 +171,7 @@ fn decodes_file_with_bframes() -> Result<(), Error> {
     let config = DecoderConfig::default();
     let mut decoder = Decoder::with_api_config(api, config)?;
 
+    // Counting frames inside video
     let mut frames = 0;
     for packet in nal_units(src) {
         if decoder.decode_with_options(packet, DecodeOptions::NoFlush)?.is_some() {
@@ -178,7 +179,10 @@ fn decodes_file_with_bframes() -> Result<(), Error> {
         }
     }
 
+    // Adding frames in buffer to the count
     frames += decoder.flush_all()?.len();
+
+    // Video should have exactly 300 frames
     assert_eq!(frames, 300);
 
     Ok(())


### PR DESCRIPTION
Fixes #50

This merge adds new methods on `Decoder` so that it doesn't break any existent code.
It also rework `mp4` example to use these methods.