### PR TITLE
Use Parallel YUV to RGB Conversion

### DIFF
--- a/openh264/Cargo.toml
+++ b/openh264/Cargo.toml
@@ -22,6 +22,7 @@ backtrace = [] # Remove once backtrace feature is stable.
 
 [dependencies]
 openh264-sys2 = { path = "../openh264-sys2", version = "0.6.0", default-features = false }
+rayon = "1.10.0"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
- adds rayon to dependencies
- converts YUV to RGB in parallel

I verified that this implementation does not change the output, but please confirm yourself.

### Benchmarks

`cargo +nightly bench convert_yuv_to_rgb_512x512`:
- before: 1,345,926.69 ns/iter (+/- 130,690.29)
- after: 784,610.09 ns/iter (+/- 62,935.31)

`cargo +nightly bench convert_yuv_to_rgb_1920x1080`:
- before: 10,846,858.90 ns/iter (+/- 1,367,686.67)
- after: 5,823,005.65 ns/iter (+/- 129,758.34)

Tested against 258849995e55b5c796c8d1087fb2d32358179d68