### PR TITLE
Improve YUV to RGB Performance II

### DIFF
--- a/openh264/src/decoder.rs
+++ b/openh264/src/decoder.rs
@@ -465,7 +465,7 @@ impl DecodedYUV<'_> {
             // calculate first RGB row
             let base_tgt = 2 * y * rgb_bytes_per_row;
             let row_target = &mut target[base_tgt..base_tgt + rgb_bytes_per_row];
-            Self::write_rgb8_f32x8_row(&y_row, &u_row, &v_row, width, row_target);
+            Self::write_rgb8_f32x8_row(y_row, u_row, v_row, width, row_target);
 
             // load Y values for second row
             let base_y = (2 * y + 1) * strides.0;
@@ -474,7 +474,7 @@ impl DecodedYUV<'_> {
             // calculate second RGB row
             let base_tgt = (2 * y + 1) * rgb_bytes_per_row;
             let row_target = &mut target[base_tgt..(base_tgt + rgb_bytes_per_row)];
-            Self::write_rgb8_f32x8_row(&y_row, &u_row, &v_row, width, row_target);
+            Self::write_rgb8_f32x8_row(y_row, u_row, v_row, width, row_target);
         }
     }
 
@@ -525,7 +525,7 @@ impl DecodedYUV<'_> {
             let (r_pack, g_pack, b_pack) = (r_pack.as_array_ref(), g_pack.as_array_ref(), b_pack.as_array_ref());
 
             for i in 0..STEP {
-                pixels[(3 * i) + 0] = r_pack[i] as u8;
+                pixels[3 * i] = r_pack[i] as u8;
                 pixels[(3 * i) + 1] = g_pack[i] as u8;
                 pixels[(3 * i) + 2] = b_pack[i] as u8;
             }

--- a/openh264/src/decoder.rs
+++ b/openh264/src/decoder.rs
@@ -395,7 +395,10 @@ impl DecodedYUV<'_> {
             target.len()
         );
 
-        if dim.0 % 8 == 0 {
+        // for f32x8 math, image needs to:
+        //   - have a width divisible by 8
+        //   - have at least two rows
+        if dim.0 % 8 == 0 && dim.1 >= 2 {
             Self::write_rgb8_f32x8(self.y, self.u, self.v, dim, strides, target);
         } else {
             Self::write_rgb8_scalar(self.y, self.u, self.v, dim, strides, target);

--- a/openh264/src/decoder.rs
+++ b/openh264/src/decoder.rs
@@ -343,7 +343,7 @@ pub struct DecodedYUV<'a> {
 /// - if block size `1` (like for Y values), you will get  `f32x8(012345678)`.
 /// - if block size is `2` (for U and V), you will get `f32x8(00112233)`
 macro_rules! f32x8_from_slice_with_blocksize {
-    ($buf:expr, $block_size:expr) => {{        
+    ($buf:expr, $block_size:expr) => {{
         wide::f32x8::from([
             ($buf[0] as f32),
             ($buf[1 / $block_size] as f32),

--- a/openh264/src/decoder.rs
+++ b/openh264/src/decoder.rs
@@ -343,8 +343,7 @@ pub struct DecodedYUV<'a> {
 /// - if block size `1` (like for Y values), you will get  `f32x8(012345678)`.
 /// - if block size is `2` (for U and V), you will get `f32x8(00112233)`
 macro_rules! f32x8_from_slice_with_blocksize {
-    ($buf:expr, $block_size:expr) => {{
-        // Use 16 Y values
+    ($buf:expr, $block_size:expr) => {{        
         wide::f32x8::from([
             ($buf[0] as f32),
             ($buf[1 / $block_size] as f32),

--- a/openh264/src/formats/yuv.rs
+++ b/openh264/src/formats/yuv.rs
@@ -363,18 +363,18 @@ mod tests {
     /// Test every YUV value and see, if the SIMD version delivers a similar RGB value.
     #[test]
     fn test_write_rgb8_f32x8_spectrum() {
-        let dim = (8, 1);
+        let dim = (8, 2);
         let strides = (8, 4, 4);
 
         // build artificial YUV planes containing the entire YUV spectrum
         for y in 0..=255u8 {
             for u in 0..=255u8 {
                 for v in 0..=255u8 {
-                    let (y_plane, u_plane, v_plane) = (vec![y; 8], vec![u; 4], vec![v; 4]);
-                    let mut target = vec![0; dim.0 * 3];
+                    let (y_plane, u_plane, v_plane) = (vec![y; 16], vec![u; 4], vec![v; 4]);
+                    let mut target = vec![0; dim.0 * dim.1 * 3];
                     crate::decoder::DecodedYUV::write_rgb8_scalar(&y_plane, &u_plane, &v_plane, dim, strides, &mut target);
 
-                    let mut target2 = vec![0; dim.0 * 3];
+                    let mut target2 = vec![0; dim.0 * dim.1 * 3];
                     crate::decoder::DecodedYUV::write_rgb8_f32x8(&y_plane, &u_plane, &v_plane, dim, strides, &mut target2);
 
                     // compare first pixel


### PR DESCRIPTION
Rewrites the YUV 2 RGB Loop
- cache u & v planes for two rows of RGB pixels
- use addition to increase indices

Before: 
```
test convert_yuv_to_rgb_512x512    ... bench:     532,512.85 ns/iter (+/- 75,759.37)
```

After:
```
test convert_yuv_to_rgb_512x512    ... bench:     444,830.35 ns/iter (+/- 38,899.95)
```