### PR TITLE
Fix wrong read_rgb call in from_rgb8_source

### DIFF
--- a/openh264/src/formats/yuv.rs
+++ b/openh264/src/formats/yuv.rs
@@ -124,7 +124,7 @@ impl YUVBuffer {
     /// May panic if invoked with an RGB source where the dimensions are not multiples of 2.
     pub fn from_rgb8_source(rgb: impl RGB8Source) -> Self {
         let mut rval = Self::new(rgb.dimensions().0, rgb.dimensions().1);
-        rval.read_rgb(rgb);
+        rval.read_rgb8(rgb);
         rval
     }
 


### PR DESCRIPTION
I saw that `YUVBuffer::from_rgb_source` and `YUVBuffer::from_rgb8_source` were very similar and had approximately the same time in benches. I believe this is a typo and the second one was supposed to call `read_rgb8` instead of `read_rgb`.

By changing that, benches changes a lot :

Before
```
test convert_rgb8_to_yuv_512x512   ... bench:   1,282,626.91 ns/iter (+/- 255,071.37)
test convert_rgb_to_yuv_512x512    ... bench:   1,361,627.65 ns/iter (+/- 24,648.61)
```

After
```
test convert_rgb8_to_yuv_512x512   ... bench:     614,115.41 ns/iter (+/- 19,137.52)
test convert_rgb_to_yuv_512x512    ... bench:   1,235,944.20 ns/iter (+/- 173,681.31)
```