### PR TITLE
Update error.rs

### DIFF
--- a/openh264/src/error.rs
+++ b/openh264/src/error.rs
@@ -12,6 +12,12 @@ pub struct Error {
 }
 
 impl Error {
+    /// Return the current native code.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn native_code(&self) -> i64 {
+        self.native
+    }
+    
     #[allow(clippy::missing_const_for_fn)]
     pub(crate) fn from_native(native: i64) -> Self {
         Self {


### PR DESCRIPTION
Return the current Error.native, which is more friendly for FFI. Fixes #72