### PR TITLE
sys: Mark source constructors as `const`

### DIFF
--- a/openh264-sys2/src/lib.rs
+++ b/openh264-sys2/src/lib.rs
@@ -101,7 +101,7 @@ pub mod source {
     #[rustfmt::skip]
     #[allow(clippy::missing_safety_doc)]
     impl APILoader {
-        pub fn new() -> Self { Self {} }
+        pub const fn new() -> Self { Self {} }
         pub unsafe fn WelsCreateSVCEncoder(&self, ppEncoder: *mut *mut ISVCEncoder) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsCreateSVCEncoder(ppEncoder) }
         pub unsafe fn WelsDestroySVCEncoder(&self, pEncoder: *mut ISVCEncoder) { crate::generated::fns_source::WelsDestroySVCEncoder(pEncoder) }
         pub unsafe fn WelsGetDecoderCapability(&self, pDecCapability: *mut SDecoderCapability) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsGetDecoderCapability(pDecCapability) }
@@ -139,7 +139,7 @@ pub enum DynamicAPI {
 impl DynamicAPI {
     /// Creates an OpenH264 API using the built-in source if available.
     #[cfg(feature = "source")]
-    pub fn from_source() -> Self {
+    pub const fn from_source() -> Self {
         let api = crate::source::APILoader::new();
         Self::Source(api)
     }


### PR DESCRIPTION
When migrating from a very old version of this library to `0.8`, it would have been convenient to store the always-available source API in a global `const API: source::APILoader` singleton, but neither `new()` nor `from_source()` are marked as `const` making that impossible.

Fortunately crate users have one alternative right now: constructing it with `APILoader {}` since there are no non-public fields; this could further be improved by removing `{}` again to simplify an alternative `(APILoader {}).Wels...()` into `APILoader.Wels...()`.  "Constructing" `APILoader` is just a Zero-Sized-Type and only used as an abstraction without containing any data/state whatsoever. At that point one might wonder if the `fn new()` constructor is still needed at all :)

Subsequently I don't understand why the `impl APILoader` block duplicates the function signaures from `impl API for APILoader`: these take `self`, and the user could already call them anyway when `API` is in scope (via `use ...::API as _;`).  If these were a non-`self` taking variant, users wouldn't have to call `(APILoader {}).Wels...()` (or the simplified variant from above) but could call `APILoader::Wels...()` directly, giving them plenty of options and alternatives.
