### PR TITLE
sys: Remove `{}` from `source::APILoader` and convert methods to associated functions

### DIFF
--- a/openh264-sys2/src/lib.rs
+++ b/openh264-sys2/src/lib.rs
@@ -101,7 +101,7 @@ pub mod source {
     #[rustfmt::skip]
     #[allow(clippy::missing_safety_doc)]
     impl APILoader {
-        pub fn new() -> Self { Self {} }
+        pub const fn new() -> Self { Self {} }
         pub unsafe fn WelsCreateSVCEncoder(&self, ppEncoder: *mut *mut ISVCEncoder) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsCreateSVCEncoder(ppEncoder) }
         pub unsafe fn WelsDestroySVCEncoder(&self, pEncoder: *mut ISVCEncoder) { crate::generated::fns_source::WelsDestroySVCEncoder(pEncoder) }
         pub unsafe fn WelsGetDecoderCapability(&self, pDecCapability: *mut SDecoderCapability) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsGetDecoderCapability(pDecCapability) }
@@ -139,7 +139,7 @@ pub enum DynamicAPI {
 impl DynamicAPI {
     /// Creates an OpenH264 API using the built-in source if available.
     #[cfg(feature = "source")]
-    pub fn from_source() -> Self {
+    pub const fn from_source() -> Self {
         let api = crate::source::APILoader::new();
         Self::Source(api)
     }

--- a/openh264-sys2/src/lib.rs
+++ b/openh264-sys2/src/lib.rs
@@ -96,31 +96,31 @@ pub mod source {
     use std::os::raw::{c_int, c_long};
 
     #[derive(Debug, Default)]
-    pub struct APILoader {}
+    pub struct APILoader;
 
     #[rustfmt::skip]
     #[allow(clippy::missing_safety_doc)]
     impl APILoader {
-        pub const fn new() -> Self { Self {} }
-        pub unsafe fn WelsCreateSVCEncoder(&self, ppEncoder: *mut *mut ISVCEncoder) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsCreateSVCEncoder(ppEncoder) }
-        pub unsafe fn WelsDestroySVCEncoder(&self, pEncoder: *mut ISVCEncoder) { crate::generated::fns_source::WelsDestroySVCEncoder(pEncoder) }
-        pub unsafe fn WelsGetDecoderCapability(&self, pDecCapability: *mut SDecoderCapability) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsGetDecoderCapability(pDecCapability) }
-        pub unsafe fn WelsCreateDecoder(&self, ppDecoder: *mut *mut ISVCDecoder) -> ::std::os::raw::c_long { crate::generated::fns_source::WelsCreateDecoder(ppDecoder) }
-        pub unsafe fn WelsDestroyDecoder(&self, pDecoder: *mut ISVCDecoder) { crate::generated::fns_source::WelsDestroyDecoder(pDecoder) }
-        pub unsafe fn WelsGetCodecVersion(&self) -> OpenH264Version { crate::generated::fns_source::WelsGetCodecVersion() }
-        pub unsafe fn WelsGetCodecVersionEx(&self, pVersion: *mut OpenH264Version) { crate::generated::fns_source::WelsGetCodecVersionEx(pVersion) }
+        pub const fn new() -> Self { Self }
+        pub unsafe fn WelsCreateSVCEncoder(ppEncoder: *mut *mut ISVCEncoder) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsCreateSVCEncoder(ppEncoder) }
+        pub unsafe fn WelsDestroySVCEncoder(pEncoder: *mut ISVCEncoder) { crate::generated::fns_source::WelsDestroySVCEncoder(pEncoder) }
+        pub unsafe fn WelsGetDecoderCapability(pDecCapability: *mut SDecoderCapability) -> ::std::os::raw::c_int { crate::generated::fns_source::WelsGetDecoderCapability(pDecCapability) }
+        pub unsafe fn WelsCreateDecoder(ppDecoder: *mut *mut ISVCDecoder) -> ::std::os::raw::c_long { crate::generated::fns_source::WelsCreateDecoder(ppDecoder) }
+        pub unsafe fn WelsDestroyDecoder(pDecoder: *mut ISVCDecoder) { crate::generated::fns_source::WelsDestroyDecoder(pDecoder) }
+        pub unsafe fn WelsGetCodecVersion() -> OpenH264Version { crate::generated::fns_source::WelsGetCodecVersion() }
+        pub unsafe fn WelsGetCodecVersionEx(pVersion: *mut OpenH264Version) { crate::generated::fns_source::WelsGetCodecVersionEx(pVersion) }
     }
 
     #[rustfmt::skip]
     #[allow(clippy::missing_safety_doc)]
     impl super::API for APILoader {
-        unsafe fn WelsCreateSVCEncoder(&self, ppEncoder: *mut *mut ISVCEncoder) -> c_int { APILoader::WelsCreateSVCEncoder(self, ppEncoder) }
-        unsafe fn WelsDestroySVCEncoder(&self, pEncoder: *mut ISVCEncoder) { APILoader::WelsDestroySVCEncoder(self, pEncoder) }
-        unsafe fn WelsGetDecoderCapability(&self, pDecCapability: *mut SDecoderCapability) -> c_int { APILoader::WelsGetDecoderCapability(self, pDecCapability) }
-        unsafe fn WelsCreateDecoder(&self, ppDecoder: *mut *mut ISVCDecoder) -> c_long { APILoader::WelsCreateDecoder(self, ppDecoder) }
-        unsafe fn WelsDestroyDecoder(&self, pDecoder: *mut ISVCDecoder) { APILoader::WelsDestroyDecoder(self, pDecoder) }
-        unsafe fn WelsGetCodecVersion(&self) -> OpenH264Version { APILoader::WelsGetCodecVersion(self) }
-        unsafe fn WelsGetCodecVersionEx(&self, pVersion: *mut OpenH264Version) { APILoader::WelsGetCodecVersionEx(self, pVersion) }
+        unsafe fn WelsCreateSVCEncoder(&self, ppEncoder: *mut *mut ISVCEncoder) -> c_int { APILoader::WelsCreateSVCEncoder(ppEncoder) }
+        unsafe fn WelsDestroySVCEncoder(&self, pEncoder: *mut ISVCEncoder) { APILoader::WelsDestroySVCEncoder(pEncoder) }
+        unsafe fn WelsGetDecoderCapability(&self, pDecCapability: *mut SDecoderCapability) -> c_int { APILoader::WelsGetDecoderCapability(pDecCapability) }
+        unsafe fn WelsCreateDecoder(&self, ppDecoder: *mut *mut ISVCDecoder) -> c_long { APILoader::WelsCreateDecoder(ppDecoder) }
+        unsafe fn WelsDestroyDecoder(&self, pDecoder: *mut ISVCDecoder) { APILoader::WelsDestroyDecoder(pDecoder) }
+        unsafe fn WelsGetCodecVersion(&self) -> OpenH264Version { APILoader::WelsGetCodecVersion() }
+        unsafe fn WelsGetCodecVersionEx(&self, pVersion: *mut OpenH264Version) { APILoader::WelsGetCodecVersionEx(pVersion) }
     }
 }
 
@@ -140,7 +140,7 @@ impl DynamicAPI {
     /// Creates an OpenH264 API using the built-in source if available.
     #[cfg(feature = "source")]
     pub const fn from_source() -> Self {
-        let api = crate::source::APILoader::new();
+        let api = crate::source::APILoader;
         Self::Source(api)
     }
 


### PR DESCRIPTION
Following up on #76, this makes it possible to call the `source` loader
in a multitude of ways:

```rust
source::APILoader::Wels...()

// Or
use API as _;
source::APILoader.Wels...()

// Or
const API: source::APILoader = source::APILoader; // Or APILoader::new() or even DynamicAPI::from_source()
use API as _;
API.Wels...()
```
