### PR TITLE
feat(encoder): add VUI support for color space signaling

### DIFF
--- a/openh264/src/encoder.rs
+++ b/openh264/src/encoder.rs
@@ -443,6 +443,7 @@ pub enum ColorPrimaries {
 
 impl ColorPrimaries {
     /// Get the raw u8 value for the VUI colour_primaries field.
+    #[must_use]
     pub const fn as_u8(self) -> u8 {
         self as u8
     }
@@ -483,6 +484,7 @@ pub enum TransferCharacteristics {
 
 impl TransferCharacteristics {
     /// Get the raw u8 value for the VUI transfer_characteristics field.
+    #[must_use]
     pub const fn as_u8(self) -> u8 {
         self as u8
     }
@@ -519,6 +521,7 @@ pub enum MatrixCoefficients {
 
 impl MatrixCoefficients {
     /// Get the raw u8 value for the VUI matrix_coefficients field.
+    #[must_use]
     pub const fn as_u8(self) -> u8 {
         self as u8
     }
@@ -538,6 +541,7 @@ impl MatrixCoefficients {
 ///     .vui(VuiConfig::bt709().with_full_range(true));  // HD BT.709 with full range
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[must_use]
 pub struct VuiConfig {
     /// Chromaticity coordinates of source primaries
     pub color_primaries: ColorPrimaries,


### PR DESCRIPTION
## Summary

Add Video Usability Information (VUI) configuration to the encoder, enabling proper color space signaling in H.264 SPS NAL units. This allows decoders to correctly interpret the encoded YUV data for accurate color reproduction.

## Motivation

When encoding video for RDP or similar protocols, color artifacts (pink/magenta tint) can occur if decoders assume the wrong color space. The underlying OpenH264 library already supports VUI fields in `SSpatialLayerConfig`, but these weren't exposed through the high-level Rust API.

This change enables applications to signal:
- Color primaries (BT.709, BT.601, BT.2020, etc.)
- Transfer characteristics (gamma curves)
- Matrix coefficients for YCbCr conversion
- Full range vs limited range video levels

## New API

```rust
use openh264::encoder::{EncoderConfig, VuiConfig};

// HD content with BT.709 (most common for desktop/web)
let config = EncoderConfig::new()
    .vui(VuiConfig::bt709());

// Full-range sRGB (for screen capture)
let config = EncoderConfig::new()
    .vui(VuiConfig::srgb());

// Custom configuration
let config = EncoderConfig::new()
    .vui(VuiConfig::bt709().with_full_range(true));
```

## Presets

- `VuiConfig::bt709()` - HD content, limited range (most common)
- `VuiConfig::srgb()` - sRGB primaries with full range (0-255)
- `VuiConfig::bt601()` - SD content
- `VuiConfig::bt2020()` - UHD/HDR content

## Technical Details

The VUI parameters map to H.264 syntax elements defined in ITU-T H.264 Tables E-3, E-4, E-5:
- `colour_primaries`
- `transfer_characteristics`
- `matrix_coefficients`
- `video_full_range_flag`

## Testing

- All existing tests pass
- Doctests included for the new API
- Tested locally with RDP streaming (internal project)

## Checklist

- [x] Code compiles without warnings
- [x] All tests pass
- [x] Documentation added with examples
- [x] Follows existing code style

See Issue #87 