### PR TITLE
Support iOS simulator targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,29 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  ios-simulator:
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-ios-sim
+          - x86_64-apple-ios
+    runs-on: macos-latest
+    env:
+      CARGO_ENCODED_RUSTFLAGS: ""
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.89
+        with:
+          targets: ${{ matrix.target }}
+      - name: LFS Checkout
+        run: git lfs checkout
+      - name: Rust - Build
+        run: cargo build --verbose --package openh264-sys2 --target=${{ matrix.target }}
+
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,29 +10,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  ios-simulator:
-    strategy:
-      matrix:
-        target:
-          - aarch64-apple-ios-sim
-          - x86_64-apple-ios
-    runs-on: macos-latest
-    env:
-      CARGO_ENCODED_RUSTFLAGS: ""
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.89
-        with:
-          targets: ${{ matrix.target }}
-      - name: LFS Checkout
-        run: git lfs checkout
-      - name: Rust - Build
-        run: cargo build --verbose --package openh264-sys2 --target=${{ matrix.target }}
-
   test:
     strategy:
       fail-fast: false
@@ -83,6 +60,14 @@ jobs:
             do-test: true
           - target: aarch64-pc-windows-msvc
             runs-on: windows-latest
+          - target: aarch64-apple-ios-sim
+            runs-on: macos-latest
+            nasm: no-nasm
+            cross-build: true
+          - target: x86_64-apple-ios
+            runs-on: macos-latest
+            nasm: no-nasm
+            cross-build: true
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
@@ -115,7 +100,13 @@ jobs:
       - name: Rust - Version
         run: rustc -Vv
       - name: Rust - Build
+        if: matrix.cross-build != true
         run: cargo build --verbose --target=${{ matrix.target }} --tests --all-features
+      - name: Rust - Cross Build
+        if: matrix.cross-build == true
+        env:
+          CARGO_ENCODED_RUSTFLAGS: ""
+        run: cargo build --verbose --package openh264-sys2 --target=${{ matrix.target }}
       - name: Rust - Style
         if: matrix.style-check == true
         run: cargo fmt --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,11 +63,11 @@ jobs:
           - target: aarch64-apple-ios-sim
             runs-on: macos-latest
             nasm: no-nasm
-            cross-build: true
+            ios-simulator: true
           - target: x86_64-apple-ios
             runs-on: macos-latest
             nasm: no-nasm
-            cross-build: true
+            ios-simulator: true
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
@@ -100,10 +100,12 @@ jobs:
       - name: Rust - Version
         run: rustc -Vv
       - name: Rust - Build
-        if: matrix.cross-build != true
+        if: matrix.ios-simulator != true
         run: cargo build --verbose --target=${{ matrix.target }} --tests --all-features
-      - name: Rust - Cross Build
-        if: matrix.cross-build == true
+      # TODO: Build the full workspace once openh264's transitive zune-jpeg
+      # dev-dependency compiles for iOS simulators.
+      - name: Rust - iOS Simulator Build
+        if: matrix.ios-simulator == true
         env:
           CARGO_ENCODED_RUSTFLAGS: ""
         run: cargo build --verbose --package openh264-sys2 --target=${{ matrix.target }}

--- a/openh264-sys2/build.rs
+++ b/openh264-sys2/build.rs
@@ -60,6 +60,7 @@ mod source_build {
         Gnu,
         Msvc,
         Musl,
+        Sim,
         Sgx,
     }
 
@@ -113,6 +114,7 @@ mod source_build {
                 "gnu" => TargetEnv::Gnu,
                 "msvc" => TargetEnv::Msvc,
                 "musl" => TargetEnv::Musl,
+                "sim" => TargetEnv::Sim,
                 "sgx" => TargetEnv::Sgx,
                 _ => panic!("Unknown target env: {env}"),
             };


### PR DESCRIPTION
## Root cause

Rust reports `target_env="sim"` for Apple simulator targets. The build script treats every unknown target environment as fatal, so `openh264-sys2` panics before compiling OpenH264 for `aarch64-apple-ios-sim` or `x86_64-apple-ios`.

## Fix

- Recognize the Apple simulator target environment explicitly.
- Cross-build `openh264-sys2` for both supported iOS simulator architectures in CI.
- Disable the repository's host-only sanitizer and `target-cpu=native` flags for those cross-builds.

## Validation

- `cargo fmt --check`
- `cargo test --package openh264-sys2`
- `env CARGO_ENCODED_RUSTFLAGS= cargo build --package openh264-sys2 --target aarch64-apple-ios-sim`
- `env CARGO_ENCODED_RUSTFLAGS= cargo build --package openh264-sys2 --target x86_64-apple-ios`

(Written by GPT-5)
